### PR TITLE
Skip creating nodes for devs with 0 fixed bugs

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -68,7 +68,7 @@ var leaderboard = {};
     for (var i in data) {
       var item = data[i];
 
-      dom += '<tr>' +
+      if (item.bugzilla.fixed) dom += '<tr>' +
         '<td><img class="avatar" src="http://www.gravatar.com/avatar/' + item.gravatar + '?s=48"></td>' +
         '<td><a href="mailto:' + item.email + '">' + item.name + '</a></td>' +
         '<td align="center"><a ' + leaderboard.bugLinksOf(item.email) + '>' +


### PR DESCRIPTION
Let's not create the table-rows for devs with only assigned bugs, but no fixed bugs.
Staging: http://mozillaindia.org/leaderboard/

May be going forward we can make expand-collapse button making its visibility optional, if really required, but for now let's test if this is good enough.
