### PR TITLE
Containerized Mozillians Leaderboard frontend using docker 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*.md
+Dockerfile
+docker-compose.yml
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Pulling the nginx image
+FROM nginx:alpine
+
+MAINTAINER kmehant<kmehant@scorelab.org>
+
+# Copying contents in to the container
+COPY . /usr/share/nginx/html
+
+# Exposing the ports for the web interface
+EXPOSE 80
+
+
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  web:
+    build: ./
+    ports:
+      - 80:80
+
+
+


### PR DESCRIPTION
I have containerized leaderboard front-end using Docker. Nginx web server is used to serve the static files at localhost.
Run this command in the git repo to serve the site at localhost.
`docker-compose up`